### PR TITLE
Fix for tensor parallelism with newly split sin/cos tensors

### DIFF
--- a/exllamav2/tensor_p.py
+++ b/exllamav2/tensor_p.py
@@ -392,8 +392,8 @@ class TPContext:
         for dev in range(self.num_devices):
             if dev in self.all_devs:
                 devctx = self.model.get_device_context(dev)
-                self.sin.append(devctx.sin)
-                self.cos.append(devctx.cos)
+                self.sin.append(torch.cat(devctx.sin, 0))
+                self.cos.append(torch.cat(devctx.cos, 0))
             else:
                 self.sin.append(none_tensor)
                 self.cos.append(none_tensor)


### PR DESCRIPTION
Since 7b05acd233cc467e19690e9434f3464a7a633e33, sin and cos in the device context are split by layer. However, the external functions `tp_attn_forward_` and `tp_attn_forward_paged_` expect a single tensor per device. I've changed the `get_sin_cos` method of the `TPContext` class to concatenate these tensors before providing them to the external functions.

The error message I was receiving before making this change was:

```
TypeError: tp_attn_forward_(): incompatible function arguments. The following argument types are supported:
    1. (arg0: int, arg1: torch.Tensor, arg2: list[torch.Tensor], arg3: list[torch.Tensor], arg4: list[torch.Tensor], arg5: list[torch.Tensor], arg6: list[torch.Tensor], arg7: list[torch.Tensor], arg8: list[torch.Tensor], arg9: list[torch.Tensor], arg10: list[torch.Tensor], arg11: list[torch.Tensor], arg12: float, arg13: list[int], arg14: list[int], arg15: list[int], arg16: list[int], arg17: int, arg18: int, arg19: int, arg20: int, arg21: list[torch.Tensor], arg22: list[torch.Tensor], arg23: list[torch.Tensor], arg24: float) -> None

Invoked with: 1399607536, tensor([[     0.00057,      0.00150,     -0.00022,  ...,     -0.00005,     -0.00012,     -0.00014],
```
followed by many more lines of truncated string representations of tensors.

I've tested this change locally, which seemed to exercise the `tp_attn_forward_` path. I'm not sure how I'd exercise the `tp_attn_forward_paged_` path. Where inference was failing before due to this error, I'm now receiving coherent output that seems consistent from what I've seen from the model before.