### PR TITLE
Added Fix for Loading unquantized Huggingface models.

### DIFF
--- a/exllamav2/config.py
+++ b/exllamav2/config.py
@@ -533,7 +533,7 @@ class ExLlamaV2Config:
                 self.vision_intermediate_size = read(read_config, int, ["vision_config->intermediate_size"], no_default)
                 self.vision_fullatt_block_indexes = read(read_config, list, ["vision_config->fullatt_block_indexes", None])
                 self.vision_window_size = read(read_config, int, ["vision_config->window_size", None])
-                assert image_processor_type == "Qwen2_5_VLImageProcessor", \
+                assert image_processor_type == "Qwen2_5_VLImageProcessor" or image_processor_type == "Qwen2VLImageProcessor", \
                     f"Wrong image processor type: {image_processor_type}"
                 self.vision_merger_intermediate_size = 5120  # TODO: This doesn't seem to appear in the config anywhere?
 

--- a/exllamav2/generator/dynamic.py
+++ b/exllamav2/generator/dynamic.py
@@ -556,6 +556,7 @@ class ExLlamaV2DynamicGenerator:
         filter_prefer_eos: bool = False,
         return_last_results: bool = False,
         embeddings: list[ExLlamaV2MMEmbedding] | list[list[ExLlamaV2MMEmbedding]] | None = None,
+        banned_strings: list | None = None,
         **kwargs
     ):
         """
@@ -616,6 +617,9 @@ class ExLlamaV2DynamicGenerator:
 
         :param embeddings:
             Optional list of ExLlamaV2MMEmbeddings to use for, or list of lists for batched generation
+
+        :param banned_strings:
+            Optional list of strings to exclude from the output
 
         :return:
             Completion(s): (str or list[str] depending on the type of the input prompt argument)
@@ -685,7 +689,8 @@ class ExLlamaV2DynamicGenerator:
                 filter_prefer_eos = filter_prefer_eos,
                 token_healing = token_healing,
                 decode_special_tokens = decode_special_tokens,
-                embeddings = embeddings[idx] or []
+                embeddings = embeddings[idx] or [],
+                banned_strings = banned_strings
             )
 
             if seed is not None: seed += 1


### PR DESCRIPTION
As per a new change in the transformers/huggingface, where they eliminated the "Qwen2_5_VLImageProcessor" type, because it was the same preprocessing as "Qwen2VLImageProcessor" due to the similar architecture, the huggingface models for Qwen2.5_VL come with "Qwen2VLImageProcessor" instead of "Qwen2_5_VLImageProcessor". 

This has resulted in a problem where the same model from huggingface cannot be used with both transformers and exllamav2 at the same time. And you have to manually edit the file to fix this when switching between frameworks.. I can't override the config either at any point through the code easily, as the code is not designed in this way (in exllamav2). 

This PR simply adjusts the check to allow for both "Qwen2_5_VLImageProcessor" and "Qwen2VLImageProcessor".

I don't think this will have any other impact. I searched the file for references for "Qwen2_5_VLImageProcessor" and found only one (in this check). 

Details of this discussion on the hugging face Repo can be found here. 
https://github.com/huggingface/transformers/issues/36193