### PR TITLE
Fix ext.py silently ignoring ImportErrors

### DIFF
--- a/exllamav2/ext.py
+++ b/exllamav2/ext.py
@@ -112,7 +112,7 @@ except ImportError as e:
         print("\"undefined symbol\" error here usually means you are attempting to load a prebuilt extension wheel "
               "that was compiled against a different version of PyTorch than the one you are you using. Please verify "
               "that the versions match.")
-        raise e
+    raise e
 
 if build_jit:
 


### PR DESCRIPTION
Turns "name 'exllamav2_ext' is not defined" (seen in #505) into more helpful errors like "libstdc++.so.6: version `GLIBCXX_3.4.30' not found".
