### PR TITLE
Hacky tensor parallel for Pixtral Large

### DIFF
--- a/exllamav2/architecture.py
+++ b/exllamav2/architecture.py
@@ -319,6 +319,7 @@ class ExLlamaV2ArchParams:
                 layer_keys_llama_mlp
             self.lm.expect_keys += \
                 expect_keys_llama
+            self.lm.supports_tp = True
 
             self.vt_prefix = "vision_tower."
             self.vt.keys.update({

--- a/exllamav2/tensor_p.py
+++ b/exllamav2/tensor_p.py
@@ -351,16 +351,24 @@ class TPContext:
         return bc_tensors
 
 
-    def copy_pinned(
-        self,
-        buffer: int,
-        inputs: torch.Tensor
-    ):
+#    def copy_pinned(
+#        self,
+#        buffer: int,
+#        inputs: torch.Tensor
+#    ):
+#        pt = self.pinned_temp[buffer][:inputs.numel()]
+#        pt = pt.view(inputs.shape)
+#        pt.copy_(inputs)
+#        return pt
+        
+    def copy_pinned(self, buffer: int, inputs: torch.Tensor):
         pt = self.pinned_temp[buffer][:inputs.numel()]
         pt = pt.view(inputs.shape)
-        pt.copy_(inputs)
-        return pt
 
+        # Bypass PyTorch entirely - direct memory copy
+        import ctypes
+        ctypes.memmove(pt.data_ptr(), inputs.data_ptr(), inputs.numel() * inputs.element_size())
+        return pt        
 
     def add_residual(
         self,


### PR DESCRIPTION
I was frustrated with TP not working on pixtral-large (its slower than qwen235b) and messed around a little bit. The model still sees images and generates text. No obvious side effects were observed, but I will test more along with other arch. Torch asserts because stuff is in inference mode and this bypasses the check with a regular copy. Somehow it's also faster by like .10 t/s.

I will also try it on qwen-VL at some point. Mainly this is here for anyone else who likes to chat with memes but wants higher speeds. Still have to test on long context too. I only did a handful of images. Maybe at 32k ctx it blows up or goes OOM. Everyone feel free to tell my why this is a horrible idea :P