### PR TITLE
DRY: Fix Greedy Clone typo in sampler.

### DIFF
--- a/exllamav2/generator/sampler.py
+++ b/exllamav2/generator/sampler.py
@@ -126,7 +126,7 @@ class ExLlamaV2Sampler:
             c.token_presence_penalty = self.token_presence_penalty
             c.token_bias = None
             c.dry_allowed_length = self.dry_allowed_length
-            c.dry_base = self.dry_allowed_length
+            c.dry_base = self.dry_base
             c.dry_multiplier = self.dry_multiplier
             c.dry_sequence_breakers = self.dry_sequence_breakers
             c.dry_max_ngram = self.dry_max_ngram


### PR DESCRIPTION
Dry base being loaded with allowed length is probably not good when those values are 1024/4096/etc. Not sure if this solves my problem yet. Either it set the penalty really high or did nothing because it's just initialization. Will test and keep looking.